### PR TITLE
Output cleanup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 libcst
+autoflake
 psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pandas
 libcst
-autoflake
 psycopg2

--- a/src/code_translation/NodeSelector.py
+++ b/src/code_translation/NodeSelector.py
@@ -52,6 +52,24 @@ class NodeSelector(cst.CSTVisitor):
             print(f"Warning: {e}")
             return cst_node
 
+    def get_sql_access_methods(self):
+        # For each InputModule.module_name, get name for sql access
+        access_methods: dict[str, cst.CSTNode] = {}
+
+        # For each library get the default sql access method
+        for library_alias, input_module in self.libraries.items():
+            access_methods[input_module.module_name] = cst.Attribute(
+                value=cst.Name(value=library_alias), attr=cst.Name(value=input_module.sql_access_method)
+            )
+
+        # If this method is directly imported without alias, use that one
+        for library_method, (input_module, _) in self.library_methods.items():
+
+            if input_module.module_name in access_methods and library_method == input_module.sql_access_method:
+                access_methods[input_module.module_name] = cst.Name(value=library_method)
+
+        return access_methods
+
     def visit_Import(self, node: cst.Import):
         imported_modules = list(node.names)
 

--- a/src/code_translation/input/dask.py
+++ b/src/code_translation/input/dask.py
@@ -7,6 +7,10 @@ class DaskInput(InputModule):
     def module_name(self) -> str:
         return "dask.dataframe"
 
+    @property
+    def sql_access_method(self) -> str:
+        return "read_sql_query"
+
     # lib methods
 
     def visit_read_sql_query(self, *args, **kwargs):

--- a/src/code_translation/input/inputModule.py
+++ b/src/code_translation/input/inputModule.py
@@ -12,6 +12,10 @@ class InputModule:
         """Return every symbol that is imported when importing * from the library"""
         return []
 
+    @property
+    def sql_access_method(self) -> str:
+        pass
+
     def resolve_call(self, method_name: str, df: bool, *args: list, **kwargs: dict) -> IRNode:
         visitor_method_name = f"visit_{'df_' if df else ''}{method_name}"
 

--- a/src/code_translation/input/pandas.py
+++ b/src/code_translation/input/pandas.py
@@ -7,6 +7,10 @@ class PandasInput(InputModule):
     def module_name(self) -> str:
         return "pandas"
 
+    @property
+    def sql_access_method(self) -> str:
+        return "read_sql"
+
     # lib methods
 
     def visit_read_sql(self, *args, **kwargs):

--- a/src/code_translation/ir/Optimizer.py
+++ b/src/code_translation/ir/Optimizer.py
@@ -42,7 +42,6 @@ class Optimizer:
                         else:
                             raise Exception(f"No sql access method for {ir_node.library}")
                         cst_translation = ir_node.to_cst_translation(sql_access_method)
-                        # TODO: Needs awareness of assignment name
                         targets = [cst.AssignTarget(target=cst.Name(target))]
                         assign = cst.Assign(targets=targets, value=cst_translation.code)
                         new_nodes.extend([cst.SimpleStatementLine(body=[node]) for node in cst_translation.precode])

--- a/src/code_translation/orchestrator.py
+++ b/src/code_translation/orchestrator.py
@@ -78,7 +78,11 @@ class Orchestrator:
         #         print()
 
         # Create Optimizer with information from NodeSelector
-        optimizer = Optimizer(variables=node_selector.variables, interesting_nodes=node_selector.interesting_nodes)
+        optimizer = Optimizer(
+            variables=node_selector.variables,
+            interesting_nodes=node_selector.interesting_nodes,
+            sql_access_methods=node_selector.get_sql_access_methods(),
+        )
         optimizer.optimize()
         optimizer.map_old_to_new_nodes()
         old_nodes_new_nodes = optimizer.get_optimized_nodes()

--- a/src/code_translation/orchestrator.py
+++ b/src/code_translation/orchestrator.py
@@ -1,3 +1,4 @@
+import autoflake
 import libcst as cst
 
 from .ir.Optimizer import Optimizer
@@ -94,6 +95,11 @@ class Orchestrator:
         # Export new_code
         new_src = new_tree.code
 
+        # Take care of linting with autoflake
+        # TODO: This does not exactly work as expected, as the requirements for 'unused variables' seem a little weird
+        new_src = autoflake.fix_code(
+            new_src, remove_all_unused_imports=True, remove_duplicate_keys=True, remove_unused_variables=True
+        )
         return new_src
 
 

--- a/src/code_translation/orchestrator.py
+++ b/src/code_translation/orchestrator.py
@@ -1,4 +1,3 @@
-import autoflake
 import libcst as cst
 
 from .ir.Optimizer import Optimizer
@@ -95,11 +94,6 @@ class Orchestrator:
         # Export new_code
         new_src = new_tree.code
 
-        # Take care of linting with autoflake
-        # TODO: This does not exactly work as expected, as the requirements for 'unused variables' seem a little weird
-        new_src = autoflake.fix_code(
-            new_src, remove_all_unused_imports=True, remove_duplicate_keys=True, remove_unused_variables=True
-        )
         return new_src
 
 

--- a/src/hisssql.py
+++ b/src/hisssql.py
@@ -16,7 +16,6 @@ def write_new_file_contents(new_file_path: str, new_contents):
 def parse_args():
     parser = ArgumentParser(description="Optimize SQL based Pandas operations for Joins and Aggregations")
     parser.add_argument("filepath", type=str, help="Path to the file you want to translate")
-    # TODO: Implement these
     parser.add_argument(
         "--inplace", type=bool, default=False, help="Whether or not to replace the file contents inplace or "
     )

--- a/src/hisssql.py
+++ b/src/hisssql.py
@@ -1,7 +1,5 @@
 from argparse import ArgumentParser
 
-import autoflake
-
 from src.code_translation.orchestrator import Orchestrator
 
 
@@ -34,12 +32,6 @@ def main():
     print(src)
 
     new_src = Orchestrator.transform(src)
-
-    # Take care of linting with autoflake
-    # TODO: This does not exactly work as expected, as the requirements for 'unused variables' seem a little weird
-    new_src = autoflake.fix_code(
-        new_src, remove_all_unused_imports=True, remove_duplicate_keys=True, remove_unused_variables=True
-    )
 
     print("New Source:")  # DEBUG
     print(new_src)

--- a/src/hisssql.py
+++ b/src/hisssql.py
@@ -1,5 +1,7 @@
 from argparse import ArgumentParser
 
+import autoflake
+
 from src.code_translation.orchestrator import Orchestrator
 
 
@@ -32,6 +34,12 @@ def main():
     print(src)
 
     new_src = Orchestrator.transform(src)
+
+    # Take care of linting with autoflake
+    # TODO: This does not exactly work as expected, as the requirements for 'unused variables' seem a little weird
+    new_src = autoflake.fix_code(
+        new_src, remove_all_unused_imports=True, remove_duplicate_keys=True, remove_unused_variables=True
+    )
 
     print("New Source:")  # DEBUG
     print(new_src)


### PR DESCRIPTION
- Added sql access methods to each InputModule (Would be moved to OutputModule in the future) to fix hardcoding of `read_sql`
- Added collection of information
- Enabled passing additional args such as connection to call (not entirely resolved, as it results in code duplication atm...)
- Added 'linting' with autoflake to remove unused imports 

Not yet fixed:
- Code duplication with passing things such as the connection. This is kinda tricky because for cases such as `query_string = '...'` we want it to be resolved into the original assignment value, however for things such as `connection = DBConnection()` we don't want it to resolve`. Do you guys have any ideas about that?
- Unused variables, it is enabled for autoflake but just doesn't do it...
- Empty lines/whitespace. This is because we the styling is saved inside the `SimpleLineStatement` which the NodeSelector does not directly have access to at the moment